### PR TITLE
CI split

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -1,0 +1,44 @@
+name: Build and test client module
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup ASP.NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.x
+    - name: Set env vars
+      run: |
+        echo "SRCDIR=./Client-Module/Client-Module" >> $GITHUB_ENV
+        echo "CSPROJ=./Client-Module/Client-Module/Client-Module.csproj" >> $GITHUB_ENV
+        echo "TESTPROJ=./Client-Module/Client-Module.Tests/ClientModule.Tests.csproj" >> $GITHUB_ENV
+        echo "TESTCOV=./Client-Module/Client-Module.Tests/cobertura.xml" >> $GITHUB_ENV
+    - name: Restore dependencies
+      run: dotnet restore ${{ env.CSPROJ }}
+    - name: Build module
+      run: dotnet build --no-restore ${{ env.CSPROJ }}
+    - name: Test module
+      run: dotnet test --verbosity normal /p:IncludeTestAssembly=true /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput="cobertura.xml" ${{ env.TESTPROJ }}
+    - name: Generate test report
+      uses: danielpalme/ReportGenerator-GitHub-Action@4.8.7
+      with:
+        reports: ${{ env.TESTCOV }}
+        targetdir: 'coverage'
+        reporttypes: 'Html'
+        sourcedirs: ${{ env.SRCDIR }}
+        verbosity: 'Warning'
+        title: Client module test coverage report
+    - name: Upload test report to GitHub
+      uses: actions/upload-artifact@v2
+      with:
+        name: Client module test report
+        path: './coverage/*'

--- a/.github/workflows/hotel.yml
+++ b/.github/workflows/hotel.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup ASP.NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.x
+        dotnet-version: 5.0.x
     - name: Set env vars
       run: |
         echo "SRCDIR=./Hotel-Module/Hotel" >> $GITHUB_ENV

--- a/.github/workflows/hotel.yml
+++ b/.github/workflows/hotel.yml
@@ -1,4 +1,4 @@
-name: ASP.NET CI
+name: Build and test hotel module
 
 on:
   pull_request:
@@ -7,32 +7,16 @@ on:
 jobs:
   build:
     strategy:
-      matrix:
-        module: [ Server, Client, Hotel ]
-    name: Build and test ${{ matrix.module }} module
+      fail-fast: false
+    name: Build and test
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Setup ASP.NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.x
-    - name: Conditionally set env vars for server module
-      if: matrix.module == 'Server'
-      run: |
-        echo "SRCDIR=./Server-Module/Server" >> $GITHUB_ENV
-        echo "CSPROJ=./Server-Module/Server/Server.csproj" >> $GITHUB_ENV
-        echo "TESTPROJ=./Server-Module/Server.Tests/Server.Tests.csproj" >> $GITHUB_ENV
-        echo "TESTCOV=./Server-Module/Server.Tests/cobertura.xml" >> $GITHUB_ENV
-    - name: Conditionally set env vars for client module
-      if: matrix.module == 'Client'
-      run: |
-        echo "SRCDIR=./Client-Module/Client-Module" >> $GITHUB_ENV
-        echo "CSPROJ=./Client-Module/Client-Module/Client-Module.csproj" >> $GITHUB_ENV
-        echo "TESTPROJ=./Client-Module/Client-Module.Tests/Client-Module.Tests.csproj" >> $GITHUB_ENV
-        echo "TESTCOV=./Client-Module/Client-Module.Tests/cobertura.xml" >> $GITHUB_ENV
-    - name: Conditionally set env vars for hotel module
-      if: matrix.module == 'Hotel'
+        dotnet-version: 5.x
+    - name: Set env vars
       run: |
         echo "SRCDIR=./Hotel-Module/Hotel" >> $GITHUB_ENV
         echo "CSPROJ=./Hotel-Module/Hotel/Hotel.csproj" >> $GITHUB_ENV
@@ -52,9 +36,9 @@ jobs:
         reporttypes: 'Html'
         sourcedirs: ${{ env.SRCDIR }}
         verbosity: 'Warning'
-        title: ${{ matrix.module }} test coverage report
+        title: Hotel module test coverage report
     - name: Upload test report to GitHub
       uses: actions/upload-artifact@v2
       with:
-        name: ${{ matrix.module }} test report
+        name: Hotel module test report
         path: './coverage/*'

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -1,0 +1,44 @@
+name: Build and test server module
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup ASP.NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.x
+    - name: Set env vars
+      run: |
+        echo "SRCDIR=./Server-Module/Server" >> $GITHUB_ENV
+        echo "CSPROJ=./Server-Module/Server/Server.csproj" >> $GITHUB_ENV
+        echo "TESTPROJ=./Server-Module/Server.Tests/Server.Tests.csproj" >> $GITHUB_ENV
+        echo "TESTCOV=./Server-Module/Server.Tests/cobertura.xml" >> $GITHUB_ENV
+    - name: Restore dependencies
+      run: dotnet restore ${{ env.CSPROJ }}
+    - name: Build module
+      run: dotnet build --no-restore ${{ env.CSPROJ }}
+    - name: Test module
+      run: dotnet test --verbosity normal /p:IncludeTestAssembly=true /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput="cobertura.xml" ${{ env.TESTPROJ }}
+    - name: Generate test report
+      uses: danielpalme/ReportGenerator-GitHub-Action@4.8.7
+      with:
+        reports: ${{ env.TESTCOV }}
+        targetdir: 'coverage'
+        reporttypes: 'Html'
+        sourcedirs: ${{ env.SRCDIR }}
+        verbosity: 'Warning'
+        title: Server module test coverage report
+    - name: Upload test report to GitHub
+      uses: actions/upload-artifact@v2
+      with:
+        name: Server module test report
+        path: './coverage/*'


### PR DESCRIPTION
To accomodate for different .NET versions across different modules I split the CI pipeline into three smaller, more configurable ones