### PR TITLE
Fix minor bug in ClientDataAccess

### DIFF
--- a/Server-Module/Server/Database/DataAccess/ClientDataAccess.cs
+++ b/Server-Module/Server/Database/DataAccess/ClientDataAccess.cs
@@ -21,8 +21,8 @@ namespace Server.Database.DataAccess
             using (var transaction = _dbContext.Database.BeginTransaction())
 			{
                 var client = _dbContext.Clients.Find(clientID);
-                client.Username = username ?? client.Username;
-                client.Email = email ?? client.Email;
+                client.Username = string.IsNullOrWhiteSpace(username) ? client.Username : username;
+                client.Email = string.IsNullOrWhiteSpace(email) ? client.Email : email;
                 _dbContext.SaveChanges();
                 transaction.Commit();
 			}


### PR DESCRIPTION
?? operator will let a whitespace name slip through if a request is fired through Postman or other equivalent app. This PR fixes that