### PR TITLE
Add basepath fix to hotel

### DIFF
--- a/Hotel-Module/Hotel/Startup.cs
+++ b/Hotel-Module/Hotel/Startup.cs
@@ -39,6 +39,12 @@ namespace Hotel
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
+            app.Use(async (context, next) =>
+            {
+                context.Request.PathBase = new Microsoft.AspNetCore.Http.PathString("/hotel");
+                await next();
+            });
+			
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();


### PR DESCRIPTION
This fixes path issues on the deployment server.

If necessary only for production scenario wrapping in
```cs
#if PRODUCTION
[...]
#endif
```

this code block is possible.

This fix has been confirmed to work for client module (#186).